### PR TITLE
[INFRASTRUCTURE] Let Carousel toString print child renderables

### DIFF
--- a/src/main/kotlin/canon/model/Carousel.kt
+++ b/src/main/kotlin/canon/model/Carousel.kt
@@ -10,5 +10,5 @@ data class Carousel(@JsonIgnore override val id: String?,
                val name: String?,
                val selected: Boolean?,
                @JsonIgnore val renderables: List<IRenderable>?) : AbstractStackable(renderables), IClassAware {
-    override fun toString() = "Carousel(text=$text, name=$name, selected=$selected)"
+    override fun toString() = "Carousel(text=$text, name=$name, selected=$selected) { ${renderables?.map { it.toString() }}"
 }


### PR DESCRIPTION
Right now when carousels are compared with their toString representation the child elements are ignored.
This way the following two would produce the same string:

<carousel>
</carousel>

<carousel>
<block><text>adsf</text></block>
<block><button>bsdf</button></block>
</carousel>

With this PR they produce different strings.