### PR TITLE
[GAIA-2051] CanonXmlValidator thread-safe

### DIFF
--- a/src/main/kotlin/canon/parser/xml/validation/CanonXmlValidator.kt
+++ b/src/main/kotlin/canon/parser/xml/validation/CanonXmlValidator.kt
@@ -1,0 +1,47 @@
+package canon.parser.xml.validation
+
+import canon.parser.xml.upgrade.xslt.XSLTTransformSupport
+import org.xml.sax.SAXException
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+
+open class CanonXmlValidator {
+
+    companion object {
+        // XMLValidator is not thread safe but resource intensive instances
+        private val VALIDATOR =  ThreadLocal.withInitial {
+            XmlValidator(CanonXmlValidator::class.java.getResourceAsStream("/xml/canon.xsd"))
+        }
+
+        @JvmStatic
+        fun getValidator() = VALIDATOR.get()!!
+    }
+
+    /**
+     * Provides the canon version used in the validation
+     * @return version of canon
+     */
+    fun getVersion(): String {
+        return XSLTTransformSupport.getCanonVersion()
+    }
+
+    /**
+     * Validates the given input stream.
+     *
+     * @param stream the input stream
+     * @return boolean
+     */
+    fun validate(stream: InputStream):XmlValidation {
+        return getValidator().validate(stream)
+    }
+
+    /**
+     * Validates the given markup text.
+     *
+     * @param markup the markup text
+     * @return boolean
+     */
+    fun validate(markup: String) = validate(markup.byteInputStream(StandardCharsets.UTF_8))
+
+
+}

--- a/src/test/kotlin/canon/parser/xml/validation/XmlValidatorTest.kt
+++ b/src/test/kotlin/canon/parser/xml/validation/XmlValidatorTest.kt
@@ -1,0 +1,54 @@
+package canon.parser.xml
+
+import canon.parser.xml.validation.CanonXmlValidator
+import canon.parser.xml.validation.XmlValidation
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class XmlValidatorTest {
+
+    @Test
+    fun parallelTest() {
+        var testFailed=false;
+        val barrier = CountDownLatch(1)
+        val endBarrier = CountDownLatch(25)
+        val validator = CanonXmlValidator()
+        (0..24).forEach {
+            Thread {
+                try{
+                    barrier.await(10, TimeUnit.SECONDS)
+                    println("Thread-${it} starting execution")
+                    validator.validate("<block></block>")
+                } catch (ex: Exception){
+                    testFailed=true;
+                    println("===>Exception was thrown ${ex.message}")
+                }
+                finally {
+                    endBarrier.countDown()
+                }
+            }.start()
+        }
+        barrier.countDown()
+        endBarrier.await(60, TimeUnit.SECONDS)
+        assertThat(testFailed).isFalse()
+    }
+
+    @Test
+    fun testSuccess() {
+        val validator = CanonXmlValidator()
+        val validation = validator.validate("<markup><container><block></block></container></markup>")
+        if(validation is XmlValidation.Failure) fail<String>("Markup should be successfully validated")
+    }
+
+
+    @Test
+    fun testFailure() {
+        val validator = CanonXmlValidator()
+        val validation = validator.validate("<markup><container><block>abc</container></markup>")
+        if(validation is XmlValidation.Success) fail<String>("Markup validation should fail!!!")
+    }
+
+}


### PR DESCRIPTION
Ich hab ein CanonXmlValidator, der Thread-safe ist, damit wir keine Lock in dem Transformer brauchen. Der CanonXmlParser verwendet diesem CanonXmlValidator auch.